### PR TITLE
Write output video

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -20,6 +20,80 @@ def rotate_poses(poses_3d, R, t):
     return poses_3d
 
 
+class VideoWriter:
+
+    def __init__(self, outfile=None):
+        self.outfile = outfile
+        self.frame_resolution = None
+        self.fps = 30  # TODO: read from video file eventually
+        self.writer = None
+
+    def write(self, frame_2d, frame_3d):
+        if not self.outfile:
+            return
+
+        # lazy-init when first frame is written
+        if not self.writer:
+            self.init_writer(frame_2d)
+
+        frame = self.combine(frame_2d, frame_3d)
+        self.writer.write(frame)
+
+    def init_writer(self, frame_2d):
+        print(f"Output will be written to {self.outfile}")
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # appears to work fine when outfile is *.mp4 or *.mov
+        height, width, _ = frame_2d.shape
+
+        self.frame_resolution = height, width  # numpy notation
+        resolution_combined = (width * 2, height)  # opencv notation
+
+        self.writer = cv2.VideoWriter(self.outfile, fourcc, self.fps, resolution_combined)
+
+    def release(self):
+        if self.outfile and self.writer:
+            self.writer.release()
+            self.outfile = None
+            print(f"Finished writing out file to {self.outfile}")
+
+    def combine(self, frame_2d, frame_3d):
+        height, width = self.frame_resolution
+
+        frame_3d = self.pad(frame_3d, height, width)
+        frame_3d = self.crop(frame_3d, height, width)
+        return  np.concatenate((frame_2d, frame_3d), axis=1)
+
+    @staticmethod
+    def pad(frame, height, width):
+        pad_top = pad_bottom = 0
+        pad_left = pad_right = 0
+
+        if height > frame.shape[0]:
+            pad_top = int((height - frame.shape[0]) / 2)
+            pad_bottom = height - frame.shape[0] - pad_top
+
+        if width > frame.shape[1]:
+            pad_left = int((width - frame.shape[1]) / 2)
+            pad_right = width - frame.shape[1] - pad_left
+
+        return cv2.copyMakeBorder(frame, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT)
+
+    @staticmethod
+    def crop(frame, height, width):
+
+        crop_top = crop_bottom = 0
+        crop_left = crop_right = 0
+
+        if frame.shape[0] > height:
+            crop_top = int((frame.shape[0] - height) / 2)
+            crop_bottom = frame.shape[0] - height - crop_top
+
+        if frame.shape[1] > width:
+            crop_left = int((frame.shape[1] - width) / 2)
+            crop_right = frame.shape[1] - width - crop_left
+
+        return frame[crop_top:frame.shape[0]-crop_bottom, crop_left:frame.shape[1]-crop_right, :]
+
+
 if __name__ == '__main__':
     parser = ArgumentParser(description='Lightweight 3D human pose estimation demo. '
                                         'Press esc to exit, "p" to (un)pause video or process next image.')
@@ -50,13 +124,9 @@ if __name__ == '__main__':
     if args.video == '' and args.images == '':
         raise ValueError('Either --video or --image has to be provided')
 
-    video_writer = None
-    if args.outfile:
-        print(f"Output will be written to {args.outfile}")
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # appears to work fine when outfile is *.mp4
-        fps = 30  # TODO: read from input file
-        resolution = (1080*2, 720)  # this is hardcoded for now
-        video_writer = cv2.VideoWriter(args.outfile, fourcc, fps, resolution)
+    if args.outfile and args.outfile == args.video:
+        raise ValueError("Cannot overwrite input video, please provide a different value for --outfile")
+    video_writer = VideoWriter(args.outfile or None)
 
     stride = 8
     if args.use_openvino:
@@ -129,19 +199,11 @@ if __name__ == '__main__':
                     (40, 80), cv2.FONT_HERSHEY_COMPLEX, 1, (0, 0, 255))
         cv2.imshow('ICV 3D Human Pose Estimation', frame)
 
-        # combine 2d + 3D frame
-        # print(frame.shape)
-        # print(canvas_3d.shape)
-
-        if video_writer:
-            combined = np.concatenate((frame, canvas_3d[:, 100:1180, :]), axis=1)
-            video_writer.write(combined)
+        video_writer.write(frame, canvas_3d)
 
         key = cv2.waitKey(delay)
         if key == esc_code:
-            if video_writer:
-                video_writer.release()
-                print(f"Finished writing out file to {args.outfile}")
+            video_writer.release()
             break
         if key == p_code:
             if delay == 1:
@@ -159,11 +221,8 @@ if __name__ == '__main__':
             if key == esc_code:
                 if video_writer:
                     video_writer.release()
-                    print(f"Finished writing out file to {args.outfile}")
                 break
             else:
                 delay = 1
 
-    if video_writer:
-        video_writer.release()
-        print(f"Finished writing out file to {args.outfile}")
+    video_writer.release()

--- a/demo.py
+++ b/demo.py
@@ -8,6 +8,7 @@ import numpy as np
 from modules.input_reader import VideoReader, ImageReader
 from modules.draw import Plotter3d, draw_poses
 from modules.parse_poses import parse_poses
+from modules.video_writer import VideoWriter
 
 
 def rotate_poses(poses_3d, R, t):
@@ -18,80 +19,6 @@ def rotate_poses(poses_3d, R, t):
         poses_3d[pose_id] = pose_3d.transpose().reshape(-1)
 
     return poses_3d
-
-
-class VideoWriter:
-
-    def __init__(self, outfile=None):
-        self.outfile = outfile
-        self.frame_resolution = None
-        self.fps = 30  # TODO: read from video file eventually
-        self.writer = None
-
-    def write(self, frame_2d, frame_3d):
-        if not self.outfile:
-            return
-
-        # lazy-init when first frame is written
-        if not self.writer:
-            self.init_writer(frame_2d)
-
-        frame = self.combine(frame_2d, frame_3d)
-        self.writer.write(frame)
-
-    def init_writer(self, frame_2d):
-        print(f"Output will be written to {self.outfile}")
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # appears to work fine when outfile is *.mp4 or *.mov
-        height, width, _ = frame_2d.shape
-
-        self.frame_resolution = height, width  # numpy notation
-        resolution_combined = (width * 2, height)  # opencv notation
-
-        self.writer = cv2.VideoWriter(self.outfile, fourcc, self.fps, resolution_combined)
-
-    def release(self):
-        if self.outfile and self.writer:
-            self.writer.release()
-            self.writer = None
-            print(f"Finished writing out file to {self.outfile}")
-
-    def combine(self, frame_2d, frame_3d):
-        height, width = self.frame_resolution
-
-        frame_3d = self.pad(frame_3d, height, width)
-        frame_3d = self.crop(frame_3d, height, width)
-        return  np.concatenate((frame_2d, frame_3d), axis=1)
-
-    @staticmethod
-    def pad(frame, height, width):
-        pad_top = pad_bottom = 0
-        pad_left = pad_right = 0
-
-        if height > frame.shape[0]:
-            pad_top = int((height - frame.shape[0]) / 2)
-            pad_bottom = height - frame.shape[0] - pad_top
-
-        if width > frame.shape[1]:
-            pad_left = int((width - frame.shape[1]) / 2)
-            pad_right = width - frame.shape[1] - pad_left
-
-        return cv2.copyMakeBorder(frame, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT)
-
-    @staticmethod
-    def crop(frame, height, width):
-
-        crop_top = crop_bottom = 0
-        crop_left = crop_right = 0
-
-        if frame.shape[0] > height:
-            crop_top = int((frame.shape[0] - height) / 2)
-            crop_bottom = frame.shape[0] - height - crop_top
-
-        if frame.shape[1] > width:
-            crop_left = int((frame.shape[1] - width) / 2)
-            crop_right = frame.shape[1] - width - crop_left
-
-        return frame[crop_top:frame.shape[0]-crop_bottom, crop_left:frame.shape[1]-crop_right, :]
 
 
 if __name__ == '__main__':

--- a/demo.py
+++ b/demo.py
@@ -52,7 +52,7 @@ class VideoWriter:
     def release(self):
         if self.outfile and self.writer:
             self.writer.release()
-            self.outfile = None
+            self.writer = None
             print(f"Finished writing out file to {self.outfile}")
 
     def combine(self, frame_2d, frame_3d):

--- a/modules/video_writer.py
+++ b/modules/video_writer.py
@@ -1,0 +1,76 @@
+import cv2
+import numpy as np
+
+
+class VideoWriter:
+
+    def __init__(self, outfile=None):
+        self.outfile = outfile
+        self.frame_resolution = None
+        self.fps = 30  # TODO: read from video file eventually
+        self.writer = None
+
+    def write(self, frame_2d, frame_3d):
+        if not self.outfile:
+            return
+
+        # lazy-init when first frame is written
+        if not self.writer:
+            self.init_writer(frame_2d)
+
+        frame = self.combine(frame_2d, frame_3d)
+        self.writer.write(frame)
+
+    def init_writer(self, frame_2d):
+        print(f"Output will be written to {self.outfile}")
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # appears to work fine when outfile is *.mp4 or *.mov
+        height, width, _ = frame_2d.shape
+
+        self.frame_resolution = height, width  # numpy notation
+        resolution_combined = (width * 2, height)  # opencv notation
+
+        self.writer = cv2.VideoWriter(self.outfile, fourcc, self.fps, resolution_combined)
+
+    def release(self):
+        if self.outfile and self.writer:
+            self.writer.release()
+            self.writer = None
+            print(f"Finished writing out file to {self.outfile}")
+
+    def combine(self, frame_2d, frame_3d):
+        height, width = self.frame_resolution
+
+        frame_3d = self.pad(frame_3d, height, width)
+        frame_3d = self.crop(frame_3d, height, width)
+        return  np.concatenate((frame_2d, frame_3d), axis=1)
+
+    @staticmethod
+    def pad(frame, height, width):
+        pad_top = pad_bottom = 0
+        pad_left = pad_right = 0
+
+        if height > frame.shape[0]:
+            pad_top = int((height - frame.shape[0]) / 2)
+            pad_bottom = height - frame.shape[0] - pad_top
+
+        if width > frame.shape[1]:
+            pad_left = int((width - frame.shape[1]) / 2)
+            pad_right = width - frame.shape[1] - pad_left
+
+        return cv2.copyMakeBorder(frame, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT)
+
+    @staticmethod
+    def crop(frame, height, width):
+
+        crop_top = crop_bottom = 0
+        crop_left = crop_right = 0
+
+        if frame.shape[0] > height:
+            crop_top = int((frame.shape[0] - height) / 2)
+            crop_bottom = frame.shape[0] - height - crop_top
+
+        if frame.shape[1] > width:
+            crop_left = int((frame.shape[1] - width) / 2)
+            crop_right = frame.shape[1] - width - crop_left
+
+        return frame[crop_top:frame.shape[0]-crop_bottom, crop_left:frame.shape[1]-crop_right, :]


### PR DESCRIPTION
This PR adds an additional CLI parameter `--outfile`. You can pass in a video file path to store a video that contains the 2d pose overlayed on the input video. The video will also include a side-by-side view of the 3d pose.

Example usage: 
```
python demo.py --video=in.mov --outfile=out.mov -m=human-pose-estimation-3d.pth
```

*Note*: When setting `--video=0` it also works for a webcam stream, put since the video writer is assuming fixed 30fps for now, the output video might look sped up compared to real-time.

This is what the output video will look like:

![image](https://user-images.githubusercontent.com/1116784/70234751-a1150f80-1761-11ea-839a-9a0804dd6d55.png)

Curious to hear feedback and if you want to merge this.


